### PR TITLE
SLING-10910 Make compatible with API 2.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.23.7-SNAPSHOT</version>
+            <version>2.24.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.21.0</version>
+            <version>2.23.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>


### PR DESCRIPTION
SLING-7975 increased the API version for o.a.s.api.resource to 2.13.0. Since the o.a.s.launchpad.test-services bundle implements an interface from that package, the module has to be recompiled so that it can work with version 2.24.0.