### PR TITLE
SLING-13077 - ExportServlet cannot adapt model to javax SlingHttpServletRequest when running in a Jakarta Servlet environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.wrappers</artifactId>
+            <version>6.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.jcr.api</artifactId>
             <version>2.4.0</version>

--- a/src/main/java/org/apache/sling/starter/testservices/exported/RequestInjected.java
+++ b/src/main/java/org/apache/sling/starter/testservices/exported/RequestInjected.java
@@ -16,6 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.sling.starter.testservices.exported;
 
-@org.osgi.annotation.versioning.Version("2.1.0")
-package org.apache.sling.starter.testservices.models;
+public interface RequestInjected {
+
+    boolean isRequestInjected();
+}

--- a/src/main/java/org/apache/sling/starter/testservices/models/DummyModel.java
+++ b/src/main/java/org/apache/sling/starter/testservices/models/DummyModel.java
@@ -23,12 +23,16 @@ import javax.annotation.PostConstruct;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.Self;
 
 @Model(adaptables = SlingHttpServletRequest.class, resourceType = "sling/test/htl/model")
 @Exporter(name = "jackson", extensions = "json")
 public class DummyModel {
 
     private String message;
+
+    @Self
+    private SlingHttpServletRequest request;
 
     @PostConstruct
     public void init() {

--- a/src/main/java/org/apache/sling/starter/testservices/models/RequestInjectionModel.java
+++ b/src/main/java/org/apache/sling/starter/testservices/models/RequestInjectionModel.java
@@ -16,6 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-@org.osgi.annotation.versioning.Version("2.1.0")
 package org.apache.sling.starter.testservices.models;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.starter.testservices.exported.RequestInjected;
+
+@SuppressWarnings("deprecation")
+@Model(adaptables = SlingHttpServletRequest.class, adapters = RequestInjected.class)
+// TODO - do we need to implement an interface to trigger the error??
+public class RequestInjectionModel implements RequestInjected {
+
+    @Self
+    private SlingHttpServletRequest slingRequest;
+
+    @Override
+    public boolean isRequestInjected() {
+        return slingRequest != null;
+    }
+}

--- a/src/main/java/org/apache/sling/starter/testservices/servlets/ModelAdaptingFromJavaxRequestServlet.java
+++ b/src/main/java/org/apache/sling/starter/testservices/servlets/ModelAdaptingFromJavaxRequestServlet.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.starter.testservices.servlets;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.apache.sling.servlets.annotations.SlingServletPathsStrict;
+import org.apache.sling.starter.testservices.exported.RequestInjected;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = Servlet.class)
+@SlingServletPathsStrict(paths = "/bin/model-from-javax-servlet", extensions = "txt")
+public class ModelAdaptingFromJavaxRequestServlet extends SlingAllMethodsServlet {
+
+    @Override
+    protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response)
+            throws ServletException, IOException {
+
+        RequestInjected model = request.adaptTo(RequestInjected.class);
+        boolean success = model != null && model.isRequestInjected();
+
+        response.setContentType("text/plain");
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.getWriter().write(String.valueOf(success));
+    }
+}


### PR DESCRIPTION
Inject the request in the DummyModel as a @Self member. This makes the test execution more strict and exposes additional failure scenarios.